### PR TITLE
fix: disable flag - De Morgan's laws convertion

### DIFF
--- a/plugin/typo.vim
+++ b/plugin/typo.vim
@@ -54,7 +54,7 @@ function! s:typo(word, level) abort
 endfunction
 
 function! s:typo_setup() abort
-  if !get(b:, 'typo_did_setup', 0) || !get(b:, 'i_naver_make_typos', 0)
+  if !get(b:, 'typo_did_setup', 0) && !get(b:, 'i_naver_make_typos', 0)
     let words = syntaxcomplete#OmniSyntaxList()
     let cache = {}
 


### PR DESCRIPTION
## Summary

When `let b:typo_did_setup = 1` is set, but do not work it.

## Reason

For disable flags of `b:typo_did_setup` and `b:i_naver_make_typos`, the expansion of De Morgan's rule was wrong.

## Fix

For enable pass, need `b:typo_did_setup` is **not** set **and** `b:i_naver_make_typos` is **not** set.